### PR TITLE
Add Linux support and fix potential unsoundness

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -90,27 +90,27 @@ dependencies = [
 
 [[package]]
 name = "dof"
-version = "0.3.0"
+version = "0.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "558e5396321b677a59d2c43b3cc3bc44683109c63ac49275f3bbbf41c0ecd002"
+checksum = "0ed9b77e3c2a83995eedff2fbf992eef44c9f319b8016254f68108e27a4d06e7"
 dependencies = [
  "goblin",
  "pretty-hex",
  "serde",
  "serde_json",
- "thiserror 1.0.69",
+ "thiserror",
  "zerocopy",
 ]
 
 [[package]]
 name = "dtrace-parser"
-version = "0.2.0"
+version = "0.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "71734e3eb68cd4df338d04dffdcc024f89eb0b238150cc95b826fbfad756452b"
+checksum = "dc09b90bda5770641457f1c0a42c8203c48f5a3d9799dcf1bafbd84e30ccf080"
 dependencies = [
  "pest",
  "pest_derive",
- "thiserror 1.0.69",
+ "thiserror",
 ]
 
 [[package]]
@@ -131,9 +131,9 @@ checksum = "07e28edb80900c19c28f1072f2e8aeca7fa06b23cd4169cefe1af5aa3260783f"
 
 [[package]]
 name = "goblin"
-version = "0.8.2"
+version = "0.10.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1b363a30c165f666402fe6a3024d3bec7ebc898f96a4a23bd1c99f8dbf3f4f47"
+checksum = "d6a80adfd63bd7ffd94fefc3d22167880c440a724303080e5aa686fa36abaa96"
 dependencies = [
  "log",
  "plain",
@@ -176,13 +176,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "32a282da65faaf38286cf3be983213fcf1d2e2a58700e808f83f4ea9a4804bc0"
 
 [[package]]
-name = "memmap"
-version = "0.7.0"
+name = "memmap2"
+version = "0.9.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6585fd95e7bb50d6cc31e20d4cf9afb4e2ba16c5846fc76793f11218da9c475b"
+checksum = "843a98750cd611cc2965a8213b53b43e715f13c37a9e096c6408e69990961db7"
 dependencies = [
  "libc",
- "winapi",
 ]
 
 [[package]]
@@ -221,7 +220,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1db05f56d34358a8b1066f67cbb203ee3e7ed2ba674a6263a1d5ec6db2204323"
 dependencies = [
  "memchr",
- "thiserror 2.0.12",
+ "thiserror",
  "ucd-trie",
 ]
 
@@ -308,18 +307,18 @@ checksum = "28d3b2b1366ec20994f1fd18c3c594f05c5dd4bc44d8bb0c1c632c8d6829481f"
 
 [[package]]
 name = "scroll"
-version = "0.12.0"
+version = "0.13.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6ab8598aa408498679922eff7fa985c25d58a90771bd6be794434c5277eab1a6"
+checksum = "c1257cd4248b4132760d6524d6dda4e053bc648c9070b960929bf50cfb1e7add"
 dependencies = [
  "scroll_derive",
 ]
 
 [[package]]
 name = "scroll_derive"
-version = "0.12.1"
+version = "0.13.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1783eabc414609e28a5ba76aee5ddd52199f7107a0b24c2e9746a1ecc34a683d"
+checksum = "ed76efe62313ab6610570951494bdaa81568026e0318eaa55f167de70eeea67d"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -409,38 +408,18 @@ dependencies = [
 
 [[package]]
 name = "thiserror"
-version = "1.0.69"
+version = "2.0.16"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b6aaf5339b578ea85b50e080feb250a3e8ae8cfcdff9a461c9ec2904bc923f52"
+checksum = "3467d614147380f2e4e374161426ff399c91084acd2363eaf549172b3d5e60c0"
 dependencies = [
- "thiserror-impl 1.0.69",
-]
-
-[[package]]
-name = "thiserror"
-version = "2.0.12"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "567b8a2dae586314f7be2a752ec7474332959c6460e02bde30d702a66d488708"
-dependencies = [
- "thiserror-impl 2.0.12",
+ "thiserror-impl",
 ]
 
 [[package]]
 name = "thiserror-impl"
-version = "1.0.69"
+version = "2.0.16"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4fee6c4efc90059e10f81e6d42c60a18f76588c3d74cb83a0b242a2b6c7504c1"
-dependencies = [
- "proc-macro2",
- "quote",
- "syn",
-]
-
-[[package]]
-name = "thiserror-impl"
-version = "2.0.12"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7f7cf42b4507d8ea322120659672cf1b9dbb93f8f2d4ecfd6e51350ff5b17a1d"
+checksum = "6c5e1be1c48b9172ee610da68fd9cd2770e7a4056cb3fc98710ee6906f0c7960"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -449,12 +428,12 @@ dependencies = [
 
 [[package]]
 name = "thread-id"
-version = "4.2.2"
+version = "5.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "cfe8f25bbdd100db7e1d34acf7fd2dc59c4bf8f7483f505eaa7d4f12f76cc0ea"
+checksum = "99043e46c5a15af379c06add30d9c93a6c0e8849de00d244c4a2c417da128d80"
 dependencies = [
  "libc",
- "winapi",
+ "windows-sys 0.59.0",
 ]
 
 [[package]]
@@ -478,7 +457,7 @@ dependencies = [
 name = "tokio-dtrace"
 version = "0.1.1"
 dependencies = [
- "thiserror 2.0.12",
+ "thiserror",
  "tokio",
  "usdt",
 ]
@@ -514,14 +493,13 @@ checksum = "5a5f39404a5da50712a4c1eecf25e90dd62b613502b7e925fd4e4d19b5c96512"
 
 [[package]]
 name = "usdt"
-version = "0.5.0"
+version = "0.6.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5bf5c47fb471a0bff3d7b17a250817bba8c6cc99b0492abaefe5b3bb99045f02"
+checksum = "1953f8d8a98ac7883c230963291acb65c7ed6ae3e2e4c99d5c65f4e65cc9db38"
 dependencies = [
  "dof",
- "dtrace-parser",
  "goblin",
- "memmap",
+ "memmap2",
  "serde",
  "usdt-attr-macro",
  "usdt-impl",
@@ -530,9 +508,9 @@ dependencies = [
 
 [[package]]
 name = "usdt-attr-macro"
-version = "0.5.0"
+version = "0.6.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "025161fff40db24774e7757f75df74ecc47e93d7e11e0f6cdfc31b40eacfe136"
+checksum = "55d0d673848744c556fcfe8479f87b6974459106e4c41f38375f6d559bb0ee28"
 dependencies = [
  "dtrace-parser",
  "proc-macro2",
@@ -544,9 +522,9 @@ dependencies = [
 
 [[package]]
 name = "usdt-impl"
-version = "0.5.0"
+version = "0.6.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f925814e5942ebb87af2d9fcf4c3f8665e37903f741eb11f0fa2396c6ef5f7b1"
+checksum = "cf0085a93af1ca095d8b1dc8672cc4620fcd1db5dff8d165486067badce05555"
 dependencies = [
  "byteorder",
  "dof",
@@ -557,16 +535,15 @@ dependencies = [
  "serde",
  "serde_json",
  "syn",
- "thiserror 1.0.69",
+ "thiserror",
  "thread-id",
- "version_check",
 ]
 
 [[package]]
 name = "usdt-macro"
-version = "0.5.0"
+version = "0.6.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3ddd86f8f3abac0b7c87f59fe82446fc96a3854a413f176dd2797ed686b7af4c"
+checksum = "c9bf594f86b676f7e2fd3d523d50f9d0cffecff6c19729ff5dbebe86c4cb8cb2"
 dependencies = [
  "dtrace-parser",
  "proc-macro2",
@@ -587,28 +564,6 @@ name = "wasi"
 version = "0.11.1+wasi-snapshot-preview1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ccf3ec651a847eb01de73ccad15eb7d99f80485de043efb2f370cd654f4ea44b"
-
-[[package]]
-name = "winapi"
-version = "0.3.9"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5c839a674fcd7a98952e593242ea400abe93992746761e38641405d28b00f419"
-dependencies = [
- "winapi-i686-pc-windows-gnu",
- "winapi-x86_64-pc-windows-gnu",
-]
-
-[[package]]
-name = "winapi-i686-pc-windows-gnu"
-version = "0.4.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ac3b87c63620426dd9b991e5ce0329eff545bccbbb34f3be09ff6fb6ab51b7b6"
-
-[[package]]
-name = "winapi-x86_64-pc-windows-gnu"
-version = "0.4.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "712e227841d057c1ee1cd2fb22fa7e5a5461ae8e48fa2ca79ec42cfc1931183f"
 
 [[package]]
 name = "windows-sys"
@@ -694,19 +649,18 @@ checksum = "589f6da84c646204747d1270a2a5661ea66ed1cced2631d546fdfb155959f9ec"
 
 [[package]]
 name = "zerocopy"
-version = "0.7.35"
+version = "0.8.27"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1b9b4fd18abc82b8136838da5d50bae7bdea537c574d8dc1a34ed098d6c166f0"
+checksum = "0894878a5fa3edfd6da3f88c4805f4c8558e2b996227a3d864f47fe11e38282c"
 dependencies = [
- "byteorder",
  "zerocopy-derive",
 ]
 
 [[package]]
 name = "zerocopy-derive"
-version = "0.7.35"
+version = "0.8.27"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "fa4f8080344d4671fb4e831a13ad1e68092748387dfc4f55e356242fae12ce3e"
+checksum = "88d2b8d9c68ad2b9e4340d7832716a4d21a22a1154777ad56ea55c51a9cf3831"
 dependencies = [
  "proc-macro2",
  "quote",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -6,6 +6,7 @@ description = "DTrace probes for Tokio"
 readme = "README.md"
 repository = "https://github.com/oxidecomputer/tokio-dtrace"
 license = "MIT OR Apache-2.0"
+rust-version = "1.85.0"
 
 [dependencies]
 thiserror = "2.0.12"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -10,7 +10,7 @@ license = "MIT OR Apache-2.0"
 [dependencies]
 thiserror = "2.0.12"
 tokio = { version = "1.46.1", features = ["rt"] }
-usdt = "0.5.0"
+usdt = "0.6.0"
 
 [dev-dependencies.tokio]
 version = "1.46.1"

--- a/examples/count-spawns.bt
+++ b/examples/count-spawns.bt
@@ -1,0 +1,8 @@
+#!/usr/bin/bpftrace
+/*
+ * When a task is spawned, count the stack that spawned it.
+ */
+usdt:$1:tokio:task-spawn
+{
+    @tasks[ustack()] = count();
+}

--- a/examples/pollstats.bt
+++ b/examples/pollstats.bt
@@ -1,0 +1,43 @@
+#!/usr/bin/bpftrace
+/*
+ * This script profiles the following:
+ * - distribution of poll durations across all tasks
+ * - distribution of total duration for which a task exists
+ * - distribution of total duration for which a task was actively being polled
+ */
+
+usdt:$1:tokio:task-spawn
+{
+    @task_poll_times[arg0] = (uint64)0;
+    @task_spawn_times[arg0] = nsecs();
+}
+
+usdt:$1:tokio:task-poll-start
+{
+    @poll_start_ts[tid] = nsecs();
+}
+
+usdt:$1:tokio:task-poll-end
+{
+    if (!has_key(@poll_start_ts, tid)) {
+        return;
+    }
+    $duration = nsecs() - @poll_start_ts[tid];
+    @durations["task poll duration", str(arg1), arg2, arg3] = hist($duration);
+    @task_poll_times[arg0] += $duration;
+    delete(@poll_start_ts, tid);
+}
+
+usdt:$1:tokio:task-terminate
+{
+    @durations["task total lifetime", str(arg1), arg2, arg3] = hist(nsecs() - @task_spawn_times[arg0]);
+    @durations["task active time", str(arg1), arg2, arg3] = hist(@task_poll_times[arg0]);
+    if (has_key(@task_poll_times, arg0))
+    {
+        delete(@task_poll_times, arg0);
+    }
+    if (has_key(@task_spawn_times, arg0))
+    {
+        delete(@task_spawn_times, arg0);
+    }
+}

--- a/examples/print-all.bt
+++ b/examples/print-all.bt
@@ -1,0 +1,19 @@
+#!/usr/bin/bpftrace
+
+usdt:$1:tokio:task-poll-start,
+usdt:$1:tokio:task-poll-end,
+usdt:$1:tokio:task-spawn,
+usdt:$1:tokio:task-terminate
+/pid == $2/
+{
+    printf("thread[%4d] %s(task=%d)\n", tid, probe, arg0);
+}
+
+usdt:$1:tokio:worker-thread-start,
+usdt:$1:tokio:worker-thread-park,
+usdt:$1:tokio:worker-thread-unpark,
+usdt:$1:tokio:worker-thread-stop
+/pid == $2/
+{
+    printf("thread[%4d] %s()\n", tid, probe);
+}


### PR DESCRIPTION
* Add support for tracepoints on Linux by upgrading to usdt 0.6.0 (semver bump of usdt).
* Add bpftrace examples that mirror the dtrace examples. bpftrace is clearly inspired by dtrace, but sufficiently different that separate examples are needed.
* Improve upon the unsafe union code converting tokio Ids to `u64`. There are two aspects to this:
   * Use static asserts rather than runtime checks. As you already use edition 2024, there is no reason to not use static asserts (static asserts was stabilised before the 2024 edition). This is a breaking change in that it removes an error variant.
   * Use `u64` instead of `NonZeroU64`: I believe the old code was unsound as it would cause UB if tokio ever changed to allow the 0 value for tasks (unlikely but theoretically possible). \
     The new code is however still unsound if tokio would change to something like `(u32, u16)` which keeps the same size but introduces padding. I'm looking for a solution to this (if one exists). See https://users.rust-lang.org/t/unsafe-unions-bit-pattern-validity/133366

This PR closes issue #3.
